### PR TITLE
feat: add support for python setup.cfg files

### DIFF
--- a/bumpanything/__main__.py
+++ b/bumpanything/__main__.py
@@ -43,6 +43,7 @@ def get_auto_detectable_file_names():
         "{}.php".format(project_name),
         # If a Python project
         "setup.py",
+        "setup.cfg",
         "pyproject.toml",
     )
 


### PR DESCRIPTION
The `setup.cfg` file is a declarative configuration file that is optional when using Python `setuptools` to define a package's metadata (including `version`) and other options.

For me personally, [Starship](https://starship.rs/) has out of the box support for Python project versions in a `setup.cfg` file but not in a `setup.py` file, and I have an older `setup.py` based project that I want to be able to easily see the version number of.