### PR TITLE
fix: changed open() to preserve line endings

### DIFF
--- a/bumpanything/__main__.py
+++ b/bumpanything/__main__.py
@@ -88,7 +88,7 @@ def replace_version_in_file_contents(file_contents, version_specifier):
 # Locate the version number in the specified file and increment it
 def bump_version_for_file(version_specifier, file_path):
     try:
-        with open(file_path, "r+") as file:
+        with open(file_path, "r+", newline="") as file:
             file_contents = file.read()
             (
                 current_version,


### PR DESCRIPTION
This change is because I want to preserve the line endings in the file(s) that `bump-anything` modifies. I use `LF` line endings in my projects even though I'm on Windows. Without this change, `bump-anything` causes my `pyproject.toml` file to be saved with `CRLF` line endings due to the default behavior of `open()`.

Edit: Sorry for the messy PR, I suck at git...